### PR TITLE
Added port to knex constructor call

### DIFF
--- a/src/plugins/core/Database/Database.js
+++ b/src/plugins/core/Database/Database.js
@@ -41,7 +41,8 @@ function buildNewConnection(dbName) {
       host: dbpluginConfig.host,
       user: dbpluginConfig.user,
       password: dbpluginConfig.password,
-      database: dbpluginConfig.database
+      database: dbpluginConfig.database,
+      port: dbpluginConfig.port
     };
   }
 


### PR DESCRIPTION
Ran into this issue today: Database plugin isn't using the configured database port.